### PR TITLE
Fix error when using URI.parse on non-ASCII strings

### DIFF
--- a/app/models/wor/post.rb
+++ b/app/models/wor/post.rb
@@ -66,12 +66,9 @@ class Wor::Post < ActiveRecord::Base
 
   # TODO, Move to module
   def resize(path, image, size)
-    Rails.logger.warn "resize method"
     return false if size.split('x').count!=2
-    Rails.logger.warn "before File.exists? check: #{size.split('x').count}"
     return false if !File.exist?(File.join(path))
 
-    Rails.logger.warn "before mkdir: #{path}/#{id}"
     FileUtils.mkdir_p "#{path}/thumbnails/#{id}" if !File.exist?(File.join(path, 'thumbnails', id.to_s))
 
     image_original_path = "#{path}/#{image}"
@@ -80,10 +77,9 @@ class Wor::Post < ActiveRecord::Base
     width  = size.split('x')[0]
     height = size.split('x')[1]
 
-    Rails.logger.warn "Magick::Image.read(#{image_original_path})"
     begin
       i = Magick::Image.read(image_original_path).first
-      Rails.logger.warn "before i.resize_to_fit"
+
       i.resize_to_fit(width.to_i,height.to_i).write(image_resized_path)
     rescue Exception => e
       Rails.logger.error e
@@ -99,7 +95,6 @@ class Wor::Post < ActiveRecord::Base
       elsif File.exist?("#{PATH_COVER_IMAGE}/thumbnails/#{id}/#{size}_#{cover_image_name}")
         "wor/cover_images/thumbnails/#{id}/#{size}_#{cover_image_name}"
       else
-        Rails.logger.warn "before resize call: wor/cover_images/thumbnails/#{id}/#{size}_#{cover_image_name}"
         "wor/cover_images/thumbnails/#{id}/#{size}_#{cover_image_name}" if resize(PATH_COVER_IMAGE, cover_image_name, size)
       end
     end

--- a/app/models/wor/post.rb
+++ b/app/models/wor/post.rb
@@ -57,7 +57,7 @@ class Wor::Post < ActiveRecord::Base
   end
 
   def cover_image?
-    File.exists?("#{PATH_COVER_IMAGE}/#{cover_image_name}")
+    File.exist?("#{PATH_COVER_IMAGE}/#{cover_image_name}")
   end
 
   def cover_image_name
@@ -69,10 +69,10 @@ class Wor::Post < ActiveRecord::Base
     Rails.logger.warn "resize method"
     return false if size.split('x').count!=2
     Rails.logger.warn "before File.exists? check: #{size.split('x').count}"
-    return false if !File.exists?(File.join(path))
+    return false if !File.exist?(File.join(path))
 
     Rails.logger.warn "before mkdir: #{path}/#{id}"
-    FileUtils.mkdir_p "#{path}/thumbnails/#{id}" if !File.exists?(File.join(path, 'thumbnails', id.to_s))
+    FileUtils.mkdir_p "#{path}/thumbnails/#{id}" if !File.exist?(File.join(path, 'thumbnails', id.to_s))
 
     image_original_path = "#{path}/#{image}"
     image_resized_path  = "#{path}/thumbnails/#{id}/#{size}_#{image}"
@@ -96,7 +96,7 @@ class Wor::Post < ActiveRecord::Base
     if cover_image?
       if size.nil?
         "wor/cover_images/#{cover_image_name}"
-      elsif File.exists?("#{PATH_COVER_IMAGE}/thumbnails/#{id}/#{size}_#{cover_image_name}")
+      elsif File.exist?("#{PATH_COVER_IMAGE}/thumbnails/#{id}/#{size}_#{cover_image_name}")
         "wor/cover_images/thumbnails/#{id}/#{size}_#{cover_image_name}"
       else
         Rails.logger.warn "before resize call: wor/cover_images/thumbnails/#{id}/#{size}_#{cover_image_name}"

--- a/app/models/wor/post.rb
+++ b/app/models/wor/post.rb
@@ -106,19 +106,26 @@ class Wor::Post < ActiveRecord::Base
   end
 
   # TODO Move to module/helper
-  def content_preprocess(size=nil)
+  def image_uri(img_src)
+    return URI.parse(URI.escape(img_src)) if RUBY_VERSION[0].to_i < 3
+
+    # Use URI::Parser when moving to Ruby 3, as URI.escape is deprecated
+    URI.parse(URI::Parser.new.escape(img_src))
+  end
+
+  def content_preprocess(size = nil)
     return content if size.nil? || content.blank?
 
     doc = Nokogiri.HTML(content)
 
-    if !doc.nil?
+    if doc.present?
       doc.search('img').each do |img|
-        img_src  = img.attributes['src'].value
+        img_src = img.attributes['src'].value
         image_name = img_src.split('/').last
 
-        if !URI.parse(img_src).path.nil?
-          image_path = URI.parse(img_src).path.gsub!(image_name, '')
-          img_src.gsub!(image_name, '')
+        if !image_uri(img_src).path.nil?
+          image_path = image_uri(img_src).path.gsub(image_name, '')
+          img_src = img_src.gsub(image_name, '')
 
           if resize(File.join(Rails.public_path, image_path), image_name, size)
             img.attributes['src'].value = "#{img_src}thumbnails/#{id}/#{size}_#{image_name}"

--- a/lib/wor/cfile.rb
+++ b/lib/wor/cfile.rb
@@ -33,7 +33,7 @@ module Wor
     # def remove_file
     #   if !extension.blank?
     #     file_path = "#{PATH}#{id}.#{extension}"
-    #     File.delete(file_path) if File.exists?(file_path)
+    #     File.delete(file_path) if File.exist?(file_path)
     #   end
     # end
   end


### PR DESCRIPTION
This PR fixes an error while trying to parse image names that contain non-ASCII characters. Alternatives for Ruby 2.x and 3.x are provided.

It also replaces some calls to `gsub!` to use `gsub` instead (the non-mutable variant), as mutating strings will raise an error when moving to Ruby 3.
